### PR TITLE
fix(vim): add redraw! to fix screen corruption after translation

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -19,6 +19,7 @@ function! TranslateSelectionToEnglish()
 
   " Replace selected lines with translation
   call setline(l:start_line, split(l:translated, "\n"))
+  redraw!
 endfunction
 
 " Map Visual mode <leader>tr to translation


### PR DESCRIPTION
This PR fixes a screen rendering issue after using the visual translation function. An explicit 'redraw!' command is added to force the screen to update correctly.

Closes #40