### PR TITLE
feat: add deepl-translate-en script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@
 bk_*
 bk_*/
 mac_osx/karabiner_elements/automatic_backups/
+
+# Exclude environment files and virtual environments
+tools/deepl-translate-en/.env
+tools/deepl-translate-en/venv/
+bin/deepl-translate-en

--- a/.zprofile
+++ b/.zprofile
@@ -171,6 +171,7 @@ source ${DOTPATH}/.zsh.d/dev/python.zsh
 zsh-defer source ${DOTPATH}/.zsh.d/networking.zsh
 # zsh-defer source ${DOTPATH}/.zsh.d/shell-tools.zsh
 zsh-defer source ${HOME}/dev/src/github.com/ontheroadjp/shell-tools/shell-tools.sh
+alias en="deepl-translate-en"
 
 #-------------------------------------------------
 # Tools

--- a/tools/deepl-translate-en/.env.example
+++ b/tools/deepl-translate-en/.env.example
@@ -1,0 +1,1 @@
+DEEPL_API_KEY=your_api_key

--- a/tools/deepl-translate-en/README.md
+++ b/tools/deepl-translate-en/README.md
@@ -1,0 +1,45 @@
+# DeepL Translate English
+
+This script translates Japanese text from the clipboard to English using the DeepL API.
+
+## Requirements
+
+- Python 3
+- See `requirements.txt` for dependencies.
+
+## Installation
+
+1.  Install the required Python libraries using pip. The `--user` flag is recommended to avoid modifying system-wide packages.
+
+    ```bash
+    python3 -m pip install --user -r /Users/hideaki/dotfiles/tools/deepl-translate-en/requirements.txt
+    ```
+
+2.  Create a `.env` file in the `tools/deepl-translate-en/` directory.
+
+3.  Add your DeepL API key to the `.env` file:
+
+    ```
+    DEEPL_API_KEY=your_api_key
+    ```
+
+## Usage
+
+1.  Copy some Japanese text to your clipboard.
+2.  Run the script:
+
+    ```bash
+    ./tools/deepl-translate-en/deepl-translate-en.py
+    ```
+
+The English translation will be printed to the standard output.
+
+You can pipe the output to `pbcopy` to copy the translation to your clipboard:
+```bash
+./tools/deepl-translate-en/deepl-translate-en.py | pbcopy
+```
+
+Or redirect it to a file:
+```bash
+./tools/deepl-translate-en/deepl-translate-en.py > translation.txt
+```

--- a/tools/deepl-translate-en/deepl-translate-en.py
+++ b/tools/deepl-translate-en/deepl-translate-en.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+This script translates Japanese text from the clipboard to English using the DeepL API.
+"""
+
+import os
+import sys
+
+if sys.version_info[0] < 3:
+    sys.stderr.write("This script requires Python 3.\n")
+    sys.exit(1)
+
+import pyperclip
+
+# Suppress the NotOpenSSLWarning for environment-dependent SSL issues.
+# This warning appears on macOS systems where the 'ssl' module is compiled with LibreSSL.
+# See: https://github.com/urllib3/urllib3/issues/3020
+import warnings
+from urllib3.exceptions import NotOpenSSLWarning
+warnings.filterwarnings("ignore", category=NotOpenSSLWarning)
+
+import requests
+from dotenv import load_dotenv
+
+def main():
+    """
+    Main function to translate clipboard text.
+    """
+    script_dir = os.path.dirname(os.path.realpath(__file__))
+    dotenv_path = os.path.join(script_dir, '.env')
+    load_dotenv(dotenv_path=dotenv_path)
+
+    api_key = os.getenv("DEEPL_API_KEY")
+    if not api_key:
+        sys.stderr.write("Error: DEEPL_API_KEY not found in .env file.\n")
+        sys.exit(1)
+
+    clipboard_text = pyperclip.paste()
+    if not clipboard_text:
+        sys.stderr.write("Error: No text found in the clipboard.\n")
+        sys.exit(1)
+
+    url = "https://api-free.deepl.com/v2/translate"
+    params = {
+        "auth_key": api_key,
+        "text": clipboard_text,
+        "source_lang": "JA",
+        "target_lang": "EN",
+    }
+
+    try:
+        response = requests.post(url, data=params)
+        response.raise_for_status()
+        translated_text = response.json()["translations"][0]["text"]
+        print(translated_text)
+    except requests.exceptions.RequestException as e:
+        sys.stderr.write(f"Error: API request failed: {e}\n")
+        sys.exit(1)
+    except (KeyError, IndexError):
+        sys.stderr.write("Error: Could not parse API response.\n")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/tools/deepl-translate-en/requirements.txt
+++ b/tools/deepl-translate-en/requirements.txt
@@ -1,0 +1,3 @@
+requests
+pyperclip
+python-dotenv

--- a/tools/deepl-translate-en/setup.sh
+++ b/tools/deepl-translate-en/setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script creates a symbolic link to the deepl-translate-en.py script
+# in the user's bin directory, so it can be run from anywhere.
+
+# Get the directory of this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# The target script
+TARGET_SCRIPT="$SCRIPT_DIR/deepl-translate-en.py"
+
+# The link name in the bin directory
+# Assuming the bin directory is at ~/dotfiles/bin
+BIN_DIR="$HOME/dotfiles/bin"
+LINK_NAME="$BIN_DIR/deepl-translate-en"
+
+# Create bin directory if it doesn't exist
+mkdir -p "$BIN_DIR"
+
+# Create the symbolic link
+if [ -L "$LINK_NAME" ]; then
+    echo "Symbolic link already exists at $LINK_NAME"
+elif [ -e "$LINK_NAME" ]; then
+    echo "Error: A file or directory already exists at $LINK_NAME"
+    exit 1
+else
+    ln -s "$TARGET_SCRIPT" "$LINK_NAME"
+    echo "Symbolic link created at $LINK_NAME"
+fi

--- a/tools/docs/deepl-translate-en.md
+++ b/tools/docs/deepl-translate-en.md
@@ -1,0 +1,36 @@
+# DeepL Translate English Tool
+
+## Overview
+
+This document provides a specification for the `deepl-translate-en.py` script.
+
+## Purpose
+
+The `deepl-translate-en.py` script is a command-line tool that translates Japanese text to English. It is designed to be simple and easy to use, integrating with the system clipboard for input.
+
+## Features
+
+-   Translates Japanese text from the clipboard to English.
+-   Uses the DeepL API for translation.
+-   Securely handles the API key using a `.env` file.
+-   Outputs the translated text to standard output.
+-   Provides clear error messages for common issues (e.g., missing API key, empty clipboard, API errors).
+
+## Technical Details
+
+-   **Language:** Python 3
+-   **Libraries:**
+    -   `requests`: For making HTTP requests to the DeepL API.
+    -   `pyperclip`: For accessing the system clipboard.
+    -   `python-dotenv`: For loading environment variables from a `.env` file.
+-   **API Endpoint:** `https://api-free.deepl.com/v2/translate`
+-   **Authentication:** The DeepL API key is passed in the `auth_key` parameter of the request.
+
+## Error Handling
+
+The script handles the following error conditions:
+
+-   **Missing `DEEPL_API_KEY`:** If the `DEEPL_API_KEY` is not found in the `.env` file, the script will print an error message to `stderr` and exit with a status code of 1.
+-   **Empty Clipboard:** If no text is found in the clipboard, the script will print an error message to `stderr` and exit with a status code of 1.
+-   **API Request Failed:** If the request to the DeepL API fails for any reason (e.g., network error, invalid API key), the script will print an error message to `stderr` and exit with a status code of 1.
+-   **Invalid API Response:** If the API response is not in the expected format, the script will print an error message to `stderr` and exit with a status code of 1.


### PR DESCRIPTION
This commit introduces a new script deepl-translate-en.py that translates Japanese text from the clipboard to English using the DeepL API.

The script is located in tools/deepl-translate-en/ and includes a README.md, requirements.txt, and .env.example.

A new documentation file has also been added in tools/docs/.

Closes #52