### PR TITLE
#69 Sync tmux session manager environment

### DIFF
--- a/docs/L3_implementation/home/tmux/.tmux.conf.md
+++ b/docs/L3_implementation/home/tmux/.tmux.conf.md
@@ -1,0 +1,29 @@
+# tmux Configuration
+
+## Purpose
+
+`home/tmux/.tmux.conf` defines terminal capabilities, environment handling, key bindings, popups, status-line behavior, shell startup, and copy-mode integration for tmux.
+
+## Behavior
+
+- The terminal layer uses `tmux-256color`, enables passthrough and extended key handling, and declares true-color support for the configured terminal types (`home/tmux/.tmux.conf:83-100`).
+- The server fixes the locale to `en_US.UTF-8` and includes `SESSION_MANAGER` in `update-environment` (`home/tmux/.tmux.conf:102-110`). When a client attaches from a new desktop login, tmux refreshes the session environment; panes created afterward inherit the current GNOME ICE socket instead of a stale value retained by a persistent tmux server.
+- Popup bindings create or attach dedicated popup sessions while preserving the current pane directory (`home/tmux/.tmux.conf:112-160`).
+- New windows and panes use `/bin/zsh` without an extra default command (`home/tmux/.tmux.conf:197-202`).
+
+## Design Decisions
+
+`SESSION_MANAGER` is synchronized rather than removed. Clipboard-enabled GTK Vim uses the variable for XSMP registration, so retaining the current value preserves session-manager integration while avoiding connection timeouts against an ICE socket from a previous GNOME login (`home/tmux/.tmux.conf:105-107`).
+
+The synchronization intentionally affects newly created panes after client attachment. tmux cannot rewrite the process environment of shells already running in existing panes; those panes may be recreated when the desktop session changes.
+
+## Integration Points
+
+- GNOME supplies `SESSION_MANAGER` to the attaching tmux client.
+- tmux copies listed client variables into the session environment through `update-environment` (`home/tmux/.tmux.conf:107`).
+- Programs launched in new panes, including GTK Vim, inherit the refreshed value.
+
+## Limitations
+
+- Existing pane processes retain the environment with which they started.
+- A client must attach with a valid `SESSION_MANAGER` before newly created panes can inherit it.

--- a/docs/L3_implementation/home/tmux/.tmux.conf.md
+++ b/docs/L3_implementation/home/tmux/.tmux.conf.md
@@ -27,3 +27,16 @@ The synchronization intentionally affects newly created panes after client attac
 
 - Existing pane processes retain the environment with which they started.
 - A client must attach with a valid `SESSION_MANAGER` before newly created panes can inherit it.
+
+## 変更履歴（git log より自動生成）
+
+- c7421ef7 fix(#69): sync tmux session manager environment
+- bca39bf4 feat(tmux): switch input to US on pane change and add tmux alias
+- 4b363e22 wip: 2026-06-21 08:16:46 before Edit .zshrc
+- 4f3f9226 clean update
+- c054136d chore(tmux,zsh): disable auto-rename and export claude title flag
+- c0e9bbaa chore(tmux,zsh): add pane title management for claude and codex
+- 0fd665e2 chore(dotfiles): add fd config, rg aliases, and refactor shell shortcuts
+- 35f01f0f chore(dotfiles): migrate git hooks, disable netrw history, enhance shell utils
+- 1745f2ab [WIP]
+- f6eadc00 [Update] many

--- a/docs/L3_implementation/specification_summary.md
+++ b/docs/L3_implementation/specification_summary.md
@@ -8,7 +8,7 @@ Core behavior under `home/zsh/zsh.d/core/` includes navigation, Git, Docker, fuz
 
 ## Vim And tmux
 
-Vim configures UTF-8, ripgrep, clipboard, indentation, and modular UI files (`home/vim/.vimrc:73-137`). tmux disables automatic renaming, rebuilds bindings, uses `tmux-256color`, and defines popup sessions (`home/tmux/.tmux.conf:1-160`).
+Vim configures UTF-8, ripgrep, clipboard, indentation, and modular UI files (`home/vim/.vimrc:73-137`). tmux disables automatic renaming, rebuilds bindings, uses `tmux-256color`, refreshes `SESSION_MANAGER` when clients attach, and defines popup sessions (`home/tmux/.tmux.conf:1-160`).
 
 ## Workstation Setup
 

--- a/home/tmux/.tmux.conf
+++ b/home/tmux/.tmux.conf
@@ -104,6 +104,7 @@ set-option -g xterm-keys on
 # -------------------------------------------
 set-environment -g LANG en_US.UTF-8
 set-environment -g LC_TIME en_US.UTF-8
+set-option -ag update-environment SESSION_MANAGER
 
 # decrease key stroke delay
 set -sg escape-time 0
@@ -313,4 +314,3 @@ bind-key -T copy-mode-vi y send -X copy-pipe-and-cancel "pbcopy"
 
 # 'Enter' to pbcopy
 bind-key -T copy-mode-vi Enter send -X copy-pipe-and-cancel "pbcopy"
-


### PR DESCRIPTION
Closes #69

## Summary

### Changed Files
- `home/tmux/.tmux.conf`: Add `SESSION_MANAGER` to tmux's client environment refresh list so new panes use the current GNOME session after re-login.
- `docs/L3_implementation/home/tmux/.tmux.conf.md`: Document tmux environment synchronization, integration points, and the existing-pane limitation.

### Change Type
- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] refactor
- [ ] chore (config/build/tooling)
- [ ] docs
- [ ] test
- [ ] other

### Handoff Notes for /docs-sync
- Design intent / background: A persistent tmux server retained a deleted GNOME ICE socket because `SESSION_MANAGER` was not in `update-environment`, causing GTK Vim's XSMP initialization to time out for one second.
- Side effects not visible in git diff: Existing panes keep their original process environment and should be recreated after a desktop re-login; newly created panes inherit the refreshed value.
- Potential misreads by docs-sync: `SESSION_MANAGER` remains enabled; this change synchronizes it rather than disabling XSMP.
- Specific docs sections to update: Vim and tmux behavior in the implementation specification summary, if needed.

## Notes for Reviewers
Verified with an isolated tmux server that reattaching changes the session environment from a stale value to the current value and that a newly created pane inherits it. Live Vim reports `+clipboard` and initializes XSMP in approximately 1 ms.

## Docs Sync Result
- Updated files: `docs/L3_implementation/specification_summary.md`, `docs/L3_implementation/home/tmux/.tmux.conf.md`
- Basis: git diff main...HEAD adopted as fact, pr-body.md referenced as supplement
- HARD STOP: none
